### PR TITLE
Highlight persists

### DIFF
--- a/src/app/components/vm-list/vm-list.component.html
+++ b/src/app/components/vm-list/vm-list.component.html
@@ -151,9 +151,8 @@ Released under a MIT (SEI)-style license. See LICENSE.md in the project root for
         "
         [matTooltip]="vm.lastError"
       >
-      <!-- don't forget to put back to normal - if literal true is here, don't merge -->
         <div
-          *ngIf="true || vm.powerState.toString() !== 'Unknown'; else notSelectable"
+          *ngIf="vm.powerState.toString() !== 'Unknown'; else notSelectable"
           [dtsSelectItem]="vm"
           fxLayout="row"
           fxLayoutAlign="start center"

--- a/src/app/components/vm-list/vm-list.component.html
+++ b/src/app/components/vm-list/vm-list.component.html
@@ -85,6 +85,20 @@ Released under a MIT (SEI)-style license. See LICENSE.md in the project root for
           >
             Shutdown
           </button>
+          <button
+            mat-menu-item
+            (click)="openSelectedHere()"
+            [disabled]="selectedVms.length === 0"  
+          >
+            Open in Player tab
+          </button>
+          <button
+            mat-menu-item
+            (click)="openSelectedBrowser()"
+            [disabled]="selectedVms.length === 0"
+          >
+            Open in browser tab
+          </button>
         </mat-menu>
 
         <div fxLayout="column" fxLayoutAlign="space-around center">
@@ -138,9 +152,10 @@ Released under a MIT (SEI)-style license. See LICENSE.md in the project root for
         "
         [matTooltip]="vm.lastError"
       >
+      <!-- TODO Remove the true here before merging - only for local testing  -->
         <div
-          *ngIf="vm.powerState.toString() !== 'Unknown'; else notSelectable"
-          [dtsSelectItem]="vm.id"
+          *ngIf="true || vm.powerState.toString() !== 'Unknown'; else notSelectable"
+          [dtsSelectItem]="vm"
           fxLayout="row"
           fxLayoutAlign="start center"
         >

--- a/src/app/components/vm-list/vm-list.component.html
+++ b/src/app/components/vm-list/vm-list.component.html
@@ -147,13 +147,13 @@ Released under a MIT (SEI)-style license. See LICENSE.md in the project root for
             | slice
               : pageEvent.pageIndex * pageEvent.pageSize
               : (pageEvent.pageIndex + 1) * pageEvent.pageSize;
-          let i = index;
           trackBy: trackByVmId
         "
         [matTooltip]="vm.lastError"
       >
+      <!-- don't forget to put back to normal - if literal true is here, don't merge -->
         <div
-          *ngIf="vm.powerState.toString() !== 'Unknown'; else notSelectable"
+          *ngIf="true || vm.powerState.toString() !== 'Unknown'; else notSelectable"
           [dtsSelectItem]="vm"
           fxLayout="row"
           fxLayoutAlign="start center"

--- a/src/app/components/vm-list/vm-list.component.html
+++ b/src/app/components/vm-list/vm-list.component.html
@@ -152,9 +152,8 @@ Released under a MIT (SEI)-style license. See LICENSE.md in the project root for
         "
         [matTooltip]="vm.lastError"
       >
-      <!-- TODO Remove the true here before merging - only for local testing  -->
         <div
-          *ngIf="true || vm.powerState.toString() !== 'Unknown'; else notSelectable"
+          *ngIf="vm.powerState.toString() !== 'Unknown'; else notSelectable"
           [dtsSelectItem]="vm"
           fxLayout="row"
           fxLayoutAlign="start center"

--- a/src/app/components/vm-list/vm-list.component.ts
+++ b/src/app/components/vm-list/vm-list.component.ts
@@ -78,8 +78,6 @@ export class VmListComponent implements OnInit, AfterViewInit {
       data: VmModel,
       filters: string
     ) => {
-      console.log('Top of filter predicate');
-
       const matchFilter = [];
       const filterArray = this.parseSearch(filters);
       const name = data.name;
@@ -153,7 +151,6 @@ export class VmListComponent implements OnInit, AfterViewInit {
   }
 
   onPage(pageEvent) {
-    console.log('On page called');
     this.pageEvent = pageEvent;
     this.selectContainer.clearSelection();
   }
@@ -167,6 +164,7 @@ export class VmListComponent implements OnInit, AfterViewInit {
     this.filterString = filterValue;
     this.vmModelDataSource.filter = filterValue.toLowerCase();
 
+    // Clear selection to avoid bug in drag select library
     this.selectContainer.clearSelection();
   }
 

--- a/src/app/components/vm-list/vm-list.component.ts
+++ b/src/app/components/vm-list/vm-list.component.ts
@@ -307,14 +307,19 @@ export class VmListComponent implements OnInit, AfterViewInit {
    * Open the selected VMs in Player tabs
    */
   public openSelectedHere() {
-    return;
+    for (const vm of this.selectedVms) {
+      const vmName = vm.name;
+      const url = vm.url;
+      const val = <{ [name: string]: string }>{ name: vmName, url };
+      this.openVmHere.emit(val);
+    }
   }
 
   /**
    * Open the selected VMs in browser tabs
    */
   public openSelectedBrowser() {
-    for (let vm of this.selectedVms) {
+    for (const vm of this.selectedVms) {
       window.open(vm.url, '_blank');
     }
   }

--- a/src/app/components/vm-list/vm-list.component.ts
+++ b/src/app/components/vm-list/vm-list.component.ts
@@ -44,7 +44,7 @@ export class VmListComponent implements OnInit, AfterViewInit {
   public filterString = '';
   public showIps = false;
   public ipv4Only = true;
-  public selectedVms = new Array<string>();
+  public selectedVms = new Array<VmModel>();
 
   @ViewChild('paginator') paginator: MatPaginator;
   @ViewChild(SelectContainerComponent)
@@ -285,11 +285,11 @@ export class VmListComponent implements OnInit, AfterViewInit {
 
           switch (action) {
             case VmAction.PowerOff:
-              return this.vmService.powerOff(this.selectedVms);
+              return this.vmService.powerOff(this.selectedVms.map(vm => vm.id));
             case VmAction.PowerOn:
-              return this.vmService.powerOn(this.selectedVms);
+              return this.vmService.powerOn(this.selectedVms.map(vm => vm.id));
             case VmAction.Shutdown:
-              return this.vmService.shutdown(this.selectedVms);
+              return this.vmService.shutdown(this.selectedVms.map(vm => vm.id));
           }
         }),
         take(1)
@@ -303,6 +303,22 @@ export class VmListComponent implements OnInit, AfterViewInit {
     return item.id;
   }
 
+  /**
+   * Open the selected VMs in Player tabs
+   */
+  public openSelectedHere() {
+    return;
+  }
+
+  /**
+   * Open the selected VMs in browser tabs
+   */
+  public openSelectedBrowser() {
+    for (let vm of this.selectedVms) {
+      window.open(vm.url, '_blank');
+    }
+  }
+ 
   /*
     Operator behaviors:
     Negation: get search results that don't include this term. Example foo -bar

--- a/src/app/components/vm-list/vm-list.component.ts
+++ b/src/app/components/vm-list/vm-list.component.ts
@@ -5,7 +5,6 @@ import { HttpEventType } from '@angular/common/http';
 import {
   AfterViewInit,
   ChangeDetectionStrategy,
-  ChangeDetectorRef,
   Component,
   EventEmitter,
   Input,
@@ -65,7 +64,6 @@ export class VmListComponent implements OnInit, AfterViewInit {
     private dialogService: DialogService,
     private teamsService: TeamsService,
     public themeService: ThemeService,
-    private changeDetector: ChangeDetectorRef,
   ) {}
 
   ngOnInit() {

--- a/src/app/components/vm-list/vm-list.component.ts
+++ b/src/app/components/vm-list/vm-list.component.ts
@@ -5,6 +5,7 @@ import { HttpEventType } from '@angular/common/http';
 import {
   AfterViewInit,
   ChangeDetectionStrategy,
+  ChangeDetectorRef,
   Component,
   EventEmitter,
   Input,
@@ -63,7 +64,8 @@ export class VmListComponent implements OnInit, AfterViewInit {
     private fileService: FileService,
     private dialogService: DialogService,
     private teamsService: TeamsService,
-    public themeService: ThemeService
+    public themeService: ThemeService,
+    private changeDetector: ChangeDetectorRef,
   ) {}
 
   ngOnInit() {
@@ -76,6 +78,8 @@ export class VmListComponent implements OnInit, AfterViewInit {
       data: VmModel,
       filters: string
     ) => {
+      console.log('Top of filter predicate');
+
       const matchFilter = [];
       const filterArray = this.parseSearch(filters);
       const name = data.name;
@@ -149,6 +153,7 @@ export class VmListComponent implements OnInit, AfterViewInit {
   }
 
   onPage(pageEvent) {
+    console.log('On page called');
     this.pageEvent = pageEvent;
     this.selectContainer.clearSelection();
   }
@@ -161,6 +166,8 @@ export class VmListComponent implements OnInit, AfterViewInit {
     this.pageEvent.pageIndex = 0;
     this.filterString = filterValue;
     this.vmModelDataSource.filter = filterValue.toLowerCase();
+
+    this.selectContainer.clearSelection();
   }
 
   /**
@@ -347,7 +354,7 @@ export class VmListComponent implements OnInit, AfterViewInit {
           token.substring(1),
         ]);
         parsed.push(term);
-      } else if (token.length == 1) {
+      } else if (this.isUnOp(token)) {
         // This is a lone unary operator - currently just means a lone '-' character
         // ignore it so we don't discard matches that don't contain a literal '-' char
         continue;
@@ -376,6 +383,10 @@ export class VmListComponent implements OnInit, AfterViewInit {
       }
     }
     return parsed;
+  }
+
+  private isUnOp(tok: string): boolean {
+    return tok == '-';
   }
 
   private isBinOp(tok: string): boolean {


### PR DESCRIPTION
Fix bug from CRU-907. The incorrect VMs were being highlighted after applying a filter. Unfortunately, this is due to a bug in the library that we use for drag to select. Now, after applying a filter, the selected VMs will simply be deselected. 