### PR TITLE
Non root user

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:14.13.1-stretch as builder
+FROM node as builder
 
 COPY package.json package-lock.json ./
 
@@ -21,6 +21,15 @@ COPY default.conf /etc/nginx/conf.d/
 
 ## Remove default nginx website
 RUN rm -rf /usr/share/nginx/html/*
+
+RUN chown -R nginx:nginx /usr/share/nginx/html      && \
+    chown -R nginx:nginx /var/cache/nginx           && \
+    chown -R nginx:nginx /var/log/nginx             && \
+    chown -R nginx:nginx /etc/nginx/conf.d          && \
+    sed -i '/user  nginx;/d' /etc/nginx/nginx.conf  && \
+    sed -i 's,/var/run/nginx.pid,/tmp/nginx.pid,' /etc/nginx/nginx.conf
+
+USER nginx
 
 ## From ‘builder’ stage copy over the artifacts in dist folder to default nginx public folder
 COPY --from=builder /ng-app/dist /usr/share/nginx/html

--- a/package.json
+++ b/package.json
@@ -36,7 +36,6 @@
     "@angular/platform-browser": "^11.2.1",
     "@angular/platform-browser-dynamic": "^11.2.1",
     "@angular/router": "^11.2.1",
-    "@cmusei/crucible-common": "0.1.0",
     "@datorama/akita": "^6.1.3",
     "@microsoft/signalr": "^5.0.5",
     "@types/uuid": "^8.3.0",
@@ -49,7 +48,8 @@
     "string-natural-compare": "^3.0.1",
     "tslib": "^2.2.0",
     "typescript": "^4.1.5",
-    "zone.js": "~0.11.4"
+    "zone.js": "^0.11.4",    
+    "@cmusei/crucible-common": "0.1.0"
   },
   "devDependencies": {
     "@angular-devkit/build-angular": "^0.1102.7",
@@ -58,21 +58,21 @@
     "@angular/language-service": "^11.2.8",
     "@datorama/akita-ng-router-store": "^6.0.0",
     "@datorama/akita-ngdevtools": "^6.0.0",
-    "@types/jasmine": "~3.6.9",
+    "@types/jasmine": "^3.6.9",
     "@types/jasminewd2": "^2.0.8",
     "@types/node": "^14.14.37",
     "codelyzer": "^6.0.1",
-    "jasmine-core": "~3.7.1",
-    "jasmine-spec-reporter": "~6.0.0",
-    "karma": "~6.3.2",
-    "karma-chrome-launcher": "~3.1.0",
-    "karma-cli": "~2.0.0",
-    "karma-coverage-istanbul-reporter": "~3.0.3",
-    "karma-jasmine": "~4.0.1",
+    "jasmine-core": "^3.7.1",
+    "jasmine-spec-reporter": "^6.0.0",
+    "karma": "^6.3.2",
+    "karma-chrome-launcher": "^3.1.0",
+    "karma-cli": "^2.0.0",
+    "karma-coverage-istanbul-reporter": "^3.0.3",
+    "karma-jasmine": "^4.0.1",
     "karma-jasmine-html-reporter": "^1.5.4",
-    "protractor": "~7.0.0",
+    "protractor": "^7.0.0",
     "ts-node": "^9.1.1",
-    "tslint": "~6.1.3",
-    "ws": "7.4.4"
+    "tslint": "^6.1.3",
+    "ws": "^7.4.4"
   }
 }


### PR DESCRIPTION
This PR switches the running user for the Docker container from root to nginx, as best-practices state to not run your containers under the root context.

Runs container in the nginx context instead of root.
Side update: change the package.json policy to use ^ consistently.
Handles internal issue CRU-1834.