### PR TITLE
fixed errors when usage logging is disabled or when no vms are present

### DIFF
--- a/src/app/components/vm-list/vm-list.component.ts
+++ b/src/app/components/vm-list/vm-list.component.ts
@@ -91,13 +91,13 @@ export class VmListComponent implements OnInit, AfterViewInit {
     private teamsService: TeamsService,
     private playerTeamService: TeamService,
     private cd: ChangeDetectorRef
-  ) {}
-
-  ngOnInit() {
+  ) {
     this.pageEvent = new PageEvent();
     this.pageEvent.pageIndex = 0;
     this.pageEvent.pageSize = this.defaultPageSize;
+  }
 
+  ngOnInit() {
     // Create a filterPredicate that tells the Search to ONLY search on the name column
     this.vmModelDataSource.filterPredicate = (
       data: VmModel,
@@ -203,7 +203,7 @@ export class VmListComponent implements OnInit, AfterViewInit {
     this.filterString = filterValue;
     this.vmModelDataSource.filter = filterValue.toLowerCase();
     if (!this.sortByTeams) {
-      this.selectContainer.clearSelection();
+      this.selectContainer?.clearSelection();
     } else {
       this.filterGroups();
       this.groupSelects.get(this.currentPanelIndex).clearSelection();
@@ -580,8 +580,6 @@ export class VmListComponent implements OnInit, AfterViewInit {
   showIpClicked(event: MatCheckboxChange) {
     this.showIPsSelectedChanged.emit(event.checked);
   }
-
-
 }
 
 enum VmAction {

--- a/src/app/components/vm-main/vm-main.component.html
+++ b/src/app/components/vm-main/vm-main.component.html
@@ -9,7 +9,8 @@ Released under a MIT (SEI)-style license. See LICENSE.md in the project root for
   fxFill
   *ngIf="currentUser$ | async as user"
 >
-  <mat-tab-group #vmTabGroup
+  <mat-tab-group
+    #vmTabGroup
     dynamicHeight
     animationDuration="0ms"
     [selectedIndex]="selectedTab"
@@ -28,18 +29,24 @@ Released under a MIT (SEI)-style license. See LICENSE.md in the project root for
       ></app-vm-list>
     </mat-tab>
     <mat-tab label="User List" #userTab>
-      <app-user-list
-        [viewId]="getCurrentViewId()"
-        [teams]="teams$ | async"
-        [isActive]="userTab.isActive"
-        (openTab)="onOpenVmHere($event)"
-      ></app-user-list>
+      <ng-template matTabContent>
+        <app-user-list
+          [viewId]="getCurrentViewId()"
+          [teams]="teams$ | async"
+          [isActive]="userTab.isActive"
+          (openTab)="onOpenVmHere($event)"
+        ></app-user-list>
+      </ng-template>
     </mat-tab>
     <mat-tab
+      *ngIf="showUsageLogging"
       label="Usage Logging"
       #LogTab
+      [disabled]="!usageLoggingEnabled"
     >
-      <app-vm-usage-logging></app-vm-usage-logging>
+      <ng-template matTabContent>
+        <app-vm-usage-logging></app-vm-usage-logging>
+      </ng-template>
     </mat-tab>
     <mat-tab *ngFor="let vm of openVms">
       <ng-template mat-tab-label>


### PR DESCRIPTION
- hide usage logging tab from non-admins rather than disable
- lazy load user list and usage logging tabs
- check for logging != null rather than just logging in if or condition fails on false
- ensure properties are initialized in vm-list when inputs are passed in