### PR TITLE
adjust vm-item sizing

### DIFF
--- a/src/app/components/vm-list/vm-item/vm-item.component.html
+++ b/src/app/components/vm-list/vm-item/vm-item.component.html
@@ -10,7 +10,10 @@ Copyright 2022 Carnegie Mellon University. All Rights Reserved.
 <ng-template #vmTemplate>
   <div [ngClass]="{ pending: vm.hasPendingTasks, error: vm.lastError }">
     <div class="vm-content" class="d-flex align-items-center">
-      <div class="m-2">
+      <div
+        class="m-2 vm-menu-button"
+        (click)="canManageTeam && onContextMenu($event)"
+      >
         <mat-icon
           *ngIf="
             vm.powerState !== undefined &&
@@ -50,27 +53,6 @@ Copyright 2022 Carnegie Mellon University. All Rights Reserved.
           "
           >{{ vm.name }}</a
         >
-      </div>
-      <div class="d-flex">
-        <button
-          mat-icon-button
-          class="tab-button"
-          (click)="openInTab(this.themeService.addThemeQueryParam(vm.url))"
-          title="Open in Browser Tab"
-        >
-          <mat-icon svgIcon="ic_open_tab"></mat-icon>
-        </button>
-        <button
-          *ngIf="canManageTeam"
-          mat-icon-button
-          (click)="onContextMenu($event)"
-          title="Team Ownership"
-        >
-          <mat-icon
-            class="team-ownership-icon"
-            svgIcon="ic_chevron_right_black_24px"
-          ></mat-icon>
-        </button>
       </div>
     </div>
     <div *ngIf="showIps" class="d-flex flex-column align-items-center content">

--- a/src/app/components/vm-list/vm-item/vm-item.component.scss
+++ b/src/app/components/vm-list/vm-item/vm-item.component.scss
@@ -5,7 +5,7 @@ Copyright 2022 Carnegie Mellon University. All Rights Reserved.
 
 .content {
   text-align: left;
-  font-size: 70%;
+  font-size: 80%;
   padding-bottom: 0.5em;
   padding-top: 0.2em;
   padding-left: 0.1em;
@@ -15,7 +15,7 @@ Copyright 2022 Carnegie Mellon University. All Rights Reserved.
 }
 
 .vm-content {
-  width: 225px;
+  width: 300px;
 }
 
 .vm-link {
@@ -68,4 +68,8 @@ Copyright 2022 Carnegie Mellon University. All Rights Reserved.
 
 .flex-none {
   flex: 0%;
+}
+
+.vm-menu-button {
+  cursor: pointer;
 }

--- a/src/app/components/vm-list/vm-item/vm-item.component.ts
+++ b/src/app/components/vm-list/vm-item/vm-item.component.ts
@@ -125,7 +125,7 @@ export class VmItemComponent implements OnInit {
     if (this.ipv4Only) {
       return vm.ipAddresses.filter((x) => !x.includes(':'));
     } else {
-      return vm.ipAddresses.concat(['1.2.3.4', '127.0.0.1', '3.4.5.6']);
+      return vm.ipAddresses;
     }
   }
 }

--- a/src/app/components/vm-list/vm-list.component.html
+++ b/src/app/components/vm-list/vm-list.component.html
@@ -177,6 +177,7 @@ Released under a MIT (SEI)-style license. See LICENSE.md in the project root for
         [matTooltip]="vm.lastError"
       >
         <vm-item
+          class="w-100"
           [dtsSelectItem]="vm.id"
           [dtsDisabled]="vm.powerState.toString() === 'Unknown'"
           [vm]="vm"

--- a/src/app/components/vm-list/vm-list.component.scss
+++ b/src/app/components/vm-list/vm-list.component.scss
@@ -22,7 +22,7 @@
   flex-flow: row;
   flex-wrap: wrap;
   text-align: left;
-  width: 225px;
+  width: 200px;
   margin-right: 40px;
   padding-top: 5px;
   padding-bottom: 5px;


### PR DESCRIPTION
- remove open in new tab button
  - vm names are now links that can be opened in new tabs natively
- remove vm menu carrot
  - moved menu to clicking on vm icon
- increase width for vm name before wrapping