### PR TITLE
fix map clickpoint editing and selection reset

### DIFF
--- a/src/app/components/map/add-point/add-point.component.ts
+++ b/src/app/components/map/add-point/add-point.component.ts
@@ -80,10 +80,21 @@ export class AddPointComponent implements OnInit {
     // Default values come from map component
     this.form = new UntypedFormGroup({
       rad: new UntypedFormControl({ value: this.rad, disabled: false }),
-      url: new UntypedFormControl({ value: '', disabled: false }),
+      url: new UntypedFormControl({ value: this.url, disabled: false }),
       label: new UntypedFormControl({ value: this.label, disabled: false }),
-      customUrl: new UntypedFormControl({ value: this.url, disabled: true }),
+      customUrl: new UntypedFormControl({ value: '', disabled: true }),
     });
+
+    if (this.editing && this.url) {
+      const vmMap = this.vmMapsQuery.getEntity(this.url);
+      if (vmMap) {
+        this.form.get('url').setValue(vmMap);
+      } else if (this.url.includes('://')) {
+        this.custom = true;
+        this.form.get('customUrl').setValue(this.url);
+        this.form.get('url').setValue('');
+      }
+    }
 
     // Get VM Maps in view
     this.vmMapsFiltered = this.route.params.pipe(
@@ -103,7 +114,7 @@ export class AddPointComponent implements OnInit {
       .valueChanges.subscribe(
         (value) =>
           (this.vmMapsFiltered = this.vmMapsQuery.getAllWithName(
-            typeof value === 'string' ? value : value.name,
+            typeof value === 'string' ? value : '',
           )),
       );
 
@@ -113,7 +124,7 @@ export class AddPointComponent implements OnInit {
       .valueChanges.subscribe(
         (value) =>
           (this.vmsFiltered = this.vmsQuery.getAllWithName(
-            typeof value === 'string' ? value : value.name,
+            typeof value === 'string' ? value : '',
           )),
       );
   }
@@ -165,8 +176,8 @@ export class AddPointComponent implements OnInit {
     return 'views/' + m.viewId + '/map/' + m.id;
   }
 
-  // Display resource name in dialog instead of url
-  display(item: Vm | VmMap): string {
+  display(item: Vm | VmMap | string): string {
+    if (typeof item === 'string') return item;
     return item && item.name ? item.name : '';
   }
 

--- a/src/app/components/map/map-main/map-main.component.html
+++ b/src/app/components/map/map-main/map-main.component.html
@@ -12,6 +12,7 @@ Released under a MIT (SEI)-style license. See LICENSE.md in the project root for
       <mat-select
         [(value)]="selected"
         [(ngModel)]="selected"
+        [compareWith]="compareMaps"
         (selectionChange)="goToMap()"
         >
         <mat-option>Select Map</mat-option>

--- a/src/app/components/map/map-main/map-main.component.ts
+++ b/src/app/components/map/map-main/map-main.component.ts
@@ -109,7 +109,10 @@ export class MapMainComponent implements OnDestroy, OnInit, AfterViewChecked {
         switchMap(() => this.getFilteredMaps(this.viewId!)),
         tap((filteredMaps) => {
           this.maps = filteredMaps;
-          if (filteredMaps.length > 0) {
+          const current = filteredMaps.find(m => m.id === this.selected?.id);
+          if (current) {
+            this.selected = current;
+          } else if (filteredMaps.length > 0) {
             this.selected = filteredMaps[0];
             this.goToMap();
           }
@@ -174,6 +177,11 @@ export class MapMainComponent implements OnDestroy, OnInit, AfterViewChecked {
   trackByMaps(index: number, item: VmMap): string {
     return item.id;
   }
+
+  compareMaps(a: VmMap, b: VmMap): boolean {
+    return a?.id === b?.id;
+  }
+
 
   delete() {
     this.dialogService

--- a/src/app/components/map/map.component.ts
+++ b/src/app/components/map/map.component.ts
@@ -120,7 +120,7 @@ export class MapComponent implements OnInit, OnChanges {
               coord.urls,
               coord.id,
               coord.label,
-              '',
+              coord.urls?.length ? coord.urls[0] : '',
               false,
             ),
           );
@@ -146,7 +146,7 @@ export class MapComponent implements OnInit, OnChanges {
 
     this.idToSend = uuidv4();
     this.selectedRad = 3;
-    this.selectedURL = 'https://example.com';
+    this.selectedURL = '';
     this.editing = false;
 
     this.dialogRef = this.dialog.open(
@@ -264,7 +264,7 @@ export class MapComponent implements OnInit, OnChanges {
     this.xActual = c.xPosition;
     this.yActual = c.yPosition;
     this.selectedRad = c.radius;
-    this.selectedURL = '';
+    this.selectedURL = c.query || '';
     this.idToSend = c.id;
     this.selectedLabel = c.label;
     this.editing = true;


### PR DESCRIPTION
Fixed two bugs with maps

- When editing an existing clickpoint, the Resource field was always blank. 
- After saving a map or submitting Edit Properties, the dropdown would reset to the first map.