### PR TITLE
Fix Map page showing 'View Not Found' when a team has no map

### DIFF
--- a/src/app/components/map/map-main/map-main.component.ts
+++ b/src/app/components/map/map-main/map-main.component.ts
@@ -106,6 +106,15 @@ export class MapMainComponent implements OnDestroy, OnInit, AfterViewChecked {
             AppTeamPermission.ManageTeam,
             AppViewPermission.ManageView,
           );
+          // Set viewExists$ based on whether a primary team exists for the
+          // view. This depends only on team permissions, not on maps, so it
+          // must be assigned here rather than inside the maps pipeline below:
+          // a valid view with no maps would otherwise never emit (see
+          // getFilteredMaps) and viewExists$ would stay undefined, falsely
+          // showing "View Not Found" instead of "No Map is assigned".
+          this.viewExists$ = this.permissionsService
+            .getPrimaryTeamId(this.viewId!)
+            .pipe(map((teamId) => !!teamId));
         }),
         switchMap(() =>
           forkJoin([
@@ -123,12 +132,6 @@ export class MapMainComponent implements OnDestroy, OnInit, AfterViewChecked {
             this.selected = filteredMaps[0];
             this.goToMap();
           }
-        }),
-        tap(() => {
-          // Set viewExists$ based on whether primary team exists
-          this.viewExists$ = this.permissionsService.getPrimaryTeamId(this.viewId!).pipe(
-            map((teamId) => !!teamId),
-          );
         }),
         takeUntil(this.unsubscribe$),
       )
@@ -153,6 +156,12 @@ export class MapMainComponent implements OnDestroy, OnInit, AfterViewChecked {
                 )
                 .pipe(map((allowed) => (allowed ? x : null)));
             });
+
+            // combineLatest([]) never emits, so a view with no maps would
+            // stall the whole pipeline. Emit an empty list explicitly.
+            if (checks$.length === 0) {
+              return of([] as VmMap[]);
+            }
 
             return combineLatest(checks$).pipe(
               map((results): VmMap[] =>

--- a/src/app/components/map/map-main/map-main.component.ts
+++ b/src/app/components/map/map-main/map-main.component.ts
@@ -106,12 +106,9 @@ export class MapMainComponent implements OnDestroy, OnInit, AfterViewChecked {
             AppTeamPermission.ManageTeam,
             AppViewPermission.ManageView,
           );
-          // Set viewExists$ based on whether a primary team exists for the
-          // view. This depends only on team permissions, not on maps, so it
-          // must be assigned here rather than inside the maps pipeline below:
-          // a valid view with no maps would otherwise never emit (see
-          // getFilteredMaps) and viewExists$ would stay undefined, falsely
-          // showing "View Not Found" instead of "No Map is assigned".
+          // Assign here, not in the maps pipeline below: a view with no maps
+          // never emits there, leaving viewExists$ undefined and falsely
+          // showing "View Not Found". View existence depends only on the team.
           this.viewExists$ = this.permissionsService
             .getPrimaryTeamId(this.viewId!)
             .pipe(map((teamId) => !!teamId));
@@ -157,8 +154,7 @@ export class MapMainComponent implements OnDestroy, OnInit, AfterViewChecked {
                 .pipe(map((allowed) => (allowed ? x : null)));
             });
 
-            // combineLatest([]) never emits, so a view with no maps would
-            // stall the whole pipeline. Emit an empty list explicitly.
+            // combineLatest([]) never emits; emit [] for a view with no maps.
             if (checks$.length === 0) {
               return of([] as VmMap[]);
             }


### PR DESCRIPTION
A valid view with no map assigned showed the 'View Not Found' page instead of 'No Map is assigned to this Team' (regression from #579).

Two coupled causes:
- getFilteredMaps returned combineLatest([]) when the view had no maps, which never emits and stalled the route pipeline.
- viewExists$ was assigned in a tap that only ran after the maps pipeline emitted, so it stayed undefined and the template treated the view as not found.

Assign viewExists$ when the view loads (it depends only on the primary team, not on maps) and emit an empty list from getFilteredMaps when there are no maps.