### PR TITLE
Fix User Follow accordion panel corner rounding

### DIFF
--- a/src/app/components/user-list/team-users/team-users.component.html
+++ b/src/app/components/user-list/team-users/team-users.component.html
@@ -3,21 +3,11 @@
  Released under a MIT (SEI)-style license. See LICENSE.md in the project root for license information.
 -->
 
-<mat-expansion-panel>
-  <mat-expansion-panel-header>
-    <mat-panel-title class="user-spacing">
-      {{ team.name }}
-    </mat-panel-title>
-    <mat-panel-description>
-      Count: {{ userDatasource.filteredData.length }}
-    </mat-panel-description>
-  </mat-expansion-panel-header>
-
-  <cdk-virtual-scroll-viewport
-    tvsItemSize="itemSize"
-    headerHeight="headerSize"
-    [ngStyle]="{ height: tableHeight }"
-  >
+<cdk-virtual-scroll-viewport
+  tvsItemSize="itemSize"
+  headerHeight="headerSize"
+  [style.height]="tableHeight"
+>
     <mat-table [dataSource]="userDatasource" matSort class="mat-elevation-z8">
       <!-- Name Column -->
       <ng-container matColumnDef="username">
@@ -94,4 +84,3 @@
       <mat-row *matRowDef="let row; columns: displayedColumns"></mat-row>
     </mat-table>
   </cdk-virtual-scroll-viewport>
-</mat-expansion-panel>

--- a/src/app/components/user-list/team-users/team-users.component.scss
+++ b/src/app/components/user-list/team-users/team-users.component.scss
@@ -8,7 +8,3 @@
   cursor: pointer;
   color: var(--mat-sys-on-surface, inherit);
 }
-
-.user-spacing {
-  flex: 30%;
-}

--- a/src/app/components/user-list/team-users/team-users.component.ts
+++ b/src/app/components/user-list/team-users/team-users.component.ts
@@ -11,6 +11,7 @@ import {
   EventEmitter,
   ViewChild,
   AfterViewInit,
+  signal,
 } from '@angular/core';
 import { ComnSettingsService } from '@cmusei/crucible-common';
 import {
@@ -32,14 +33,8 @@ import {
   MatRowDef,
   MatRow,
 } from '@angular/material/table';
-import { NgStyle, NgIf, AsyncPipe, DatePipe } from '@angular/common';
+import { NgIf, AsyncPipe, DatePipe } from '@angular/common';
 import { CdkVirtualScrollViewport } from '@angular/cdk/scrolling';
-import {
-  MatExpansionPanel,
-  MatExpansionPanelHeader,
-  MatExpansionPanelTitle,
-  MatExpansionPanelDescription,
-} from '@angular/material/expansion';
 import { MatSort, MatSortModule } from '@angular/material/sort';
 import { VmUser } from '../../../generated/vm-api';
 
@@ -49,13 +44,8 @@ import { VmUser } from '../../../generated/vm-api';
     styleUrls: ['./team-users.component.scss'],
     changeDetection: ChangeDetectionStrategy.OnPush,
     imports: [
-        MatExpansionPanel,
-        MatExpansionPanelHeader,
-        MatExpansionPanelTitle,
-        MatExpansionPanelDescription,
         CdkVirtualScrollViewport,
         TableVirtualScrollModule,
-        NgStyle,
         MatTable,
         MatColumnDef,
         MatHeaderCellDef,
@@ -120,6 +110,7 @@ export class TeamUsersComponent implements AfterViewInit {
   public headerSize = 56;
   public maxSize = this.itemSize * 7;
   public tableHeight = '0px';
+  public filteredCount = signal(0);
 
   @ViewChild(MatSort) sort: MatSort;
 
@@ -214,6 +205,7 @@ export class TeamUsersComponent implements AfterViewInit {
 
   calculateTableHeight() {
     const count = this.userDatasource.filteredData.length;
+    this.filteredCount.set(count);
     let height: number;
     height = this.headerSize * 1.2 + count * this.itemSize;
 

--- a/src/app/components/user-list/user-list.component.html
+++ b/src/app/components/user-list/user-list.component.html
@@ -79,8 +79,17 @@ Released under a MIT (SEI)-style license. See LICENSE.md in the project root for
       <mat-accordion multi>
         @for (team of _teams; track trackByTeamId(team)) {
           @if (team?.id) {
-            <div>
+            <mat-expansion-panel>
+              <mat-expansion-panel-header>
+                <mat-panel-title class="user-spacing">
+                  {{ team.name }}
+                </mat-panel-title>
+                <mat-panel-description>
+                  Count: {{ teamUsers.filteredCount() }}
+                </mat-panel-description>
+              </mat-expansion-panel-header>
               <app-team-users
+                #teamUsers
                 [team]="team"
                 [users]="userQueryMap.get(team.id) | async"
                 [searchTerm]="searchTerm$ | async"
@@ -89,7 +98,7 @@ Released under a MIT (SEI)-style license. See LICENSE.md in the project root for
                 [recentMinutes]="recentMinutes"
                 (openTab)="onOpenTab($event)"
               ></app-team-users>
-            </div>
+            </mat-expansion-panel>
           }
         }
       </mat-accordion>

--- a/src/app/components/user-list/user-list.component.scss
+++ b/src/app/components/user-list/user-list.component.scss
@@ -6,3 +6,7 @@
 .searchBox {
   width: 300px;
 }
+
+.user-spacing {
+  flex: 30%;
+}

--- a/src/app/components/user-list/user-list.component.ts
+++ b/src/app/components/user-list/user-list.component.ts
@@ -11,7 +11,13 @@ import {
   Output,
   EventEmitter,
 } from '@angular/core';
-import { MatAccordion } from '@angular/material/expansion';
+import {
+  MatAccordion,
+  MatExpansionPanel,
+  MatExpansionPanelHeader,
+  MatExpansionPanelTitle,
+  MatExpansionPanelDescription,
+} from '@angular/material/expansion';
 import { BehaviorSubject, Observable } from 'rxjs';
 import { debounceTime } from 'rxjs/operators';
 import { VmTeam } from '../../state/vm-teams/vm-team.model';
@@ -51,6 +57,10 @@ import { VmUser } from '../../generated/vm-api';
     MatButton,
     MatCheckbox,
     MatAccordion,
+    MatExpansionPanel,
+    MatExpansionPanelHeader,
+    MatExpansionPanelTitle,
+    MatExpansionPanelDescription,
     TeamUsersComponent,
     AsyncPipe,
     MatOption,


### PR DESCRIPTION
## Problem

In the **User Follow** tab, the `mat-accordion` of team expansion panels rendered with every panel individually rounded on all four corners, instead of one cohesive accordion (rounded only at the very top and bottom). The accordion appeared not to recognize the panels as its children.

## Root cause

Each `<mat-expansion-panel>` lived inside the `app-team-users` child component, which itself sat inside a wrapper `<div>` in the `@for`. Angular Material rounds the group's outer corners with `.mat-accordion .mat-expansion-panel:first-of-type` / `:last-of-type`. Those `*-of-type` pseudo-classes match relative to an element's **DOM siblings**, and each panel was the lone child of its own host — so every panel was simultaneously the first *and* last of its type and received both top and bottom rounding.

(The commonly suggested `display: contents` does not fix this — it only affects the layout/box tree, not structural selector matching.)

## Fix

Lift `<mat-expansion-panel>` and its header up into `user-list.component.html` so the panels are **true DOM children of `<mat-accordion>`**. Material's native rounding then works with no CSS overrides, no `::ng-deep`, no `!important`. `app-team-users` now renders only the virtual-scroll table body.

The header's user count (previously derived inside the child) is exposed via a `filteredCount` signal on the child, read in the parent header through a template reference variable — reactive and OnPush-safe.

Also applied minor best-practice cleanup flagged by the Angular CLI guide: `[ngStyle]` → `[style.height]` (dropping the now-unused `NgStyle` import).