### PR TITLE
Handle empty VM-by-name console lookup gracefully

### DIFF
--- a/src/app/components/console/console.component.html
+++ b/src/app/components/console/console.component.html
@@ -3,4 +3,15 @@ Copyright 2021 Carnegie Mellon University. All Rights Reserved.
 Released under a MIT (SEI)-style license. See LICENSE.md in the project root for license information.
 -->
 
-Loading...
+@if (loading) {
+  Loading...
+} @else if (notFound) {
+  <app-page-not-found
+    heading="Virtual Machine Not Found"
+    [message]="
+      'No virtual machines named &quot;' +
+      name +
+      '&quot; were found that you have permission to access.'
+    "
+  ></app-page-not-found>
+}

--- a/src/app/components/console/console.component.html
+++ b/src/app/components/console/console.component.html
@@ -3,14 +3,14 @@ Copyright 2021 Carnegie Mellon University. All Rights Reserved.
 Released under a MIT (SEI)-style license. See LICENSE.md in the project root for license information.
 -->
 
-@if (loading) {
+@if (loading()) {
   Loading...
-} @else if (notFound) {
+} @else if (notFound()) {
   <app-page-not-found
     heading="Virtual Machine Not Found"
     [message]="
       'No virtual machines named &quot;' +
-      name +
+      name() +
       '&quot; were found that you have permission to access.'
     "
   ></app-page-not-found>

--- a/src/app/components/console/console.component.ts
+++ b/src/app/components/console/console.component.ts
@@ -5,14 +5,20 @@ import { Component, OnInit } from '@angular/core';
 import { ActivatedRoute } from '@angular/router';
 import { VmService } from '../../state/vms/vms.service';
 import { ThemeService } from '../../services/theme/theme.service';
+import { PageNotFoundComponent } from '../page-not-found/page-not-found.component';
 
 @Component({
   selector: 'app-console',
   templateUrl: './console.component.html',
   styleUrls: ['./console.component.scss'],
   standalone: true,
+  imports: [PageNotFoundComponent],
 })
 export class ConsoleComponent implements OnInit {
+  loading = true;
+  notFound = false;
+  name = '';
+
   constructor(
     private vmService: VmService,
     private route: ActivatedRoute,
@@ -21,19 +27,23 @@ export class ConsoleComponent implements OnInit {
 
   ngOnInit() {
     const viewId = this.route.snapshot.params['viewId'];
-    const name = this.route.snapshot.params['name'];
+    this.name = this.route.snapshot.params['name'];
 
-    this.vmService.GetViewVmsByName(viewId, name).subscribe(
+    this.vmService.GetViewVmsByName(viewId, this.name).subscribe(
       (vms) => {
-        if (vms != null) {
-          const vm = vms[0];
+        const vm = vms != null ? vms[0] : null;
 
-          if (vm) {
-            window.location.href = this.themeService.addThemeQueryParam(vm.url);
-          }
+        if (vm) {
+          window.location.href = this.themeService.addThemeQueryParam(vm.url);
+        } else {
+          this.loading = false;
+          this.notFound = true;
         }
       },
-      (err) => {},
+      (err) => {
+        this.loading = false;
+        this.notFound = true;
+      },
     );
   }
 }

--- a/src/app/components/console/console.component.ts
+++ b/src/app/components/console/console.component.ts
@@ -1,7 +1,7 @@
 // Copyright 2021 Carnegie Mellon University. All Rights Reserved.
 // Released under a MIT (SEI)-style license. See LICENSE.md in the project root for license information.
 
-import { Component, OnInit } from '@angular/core';
+import { Component, OnInit, signal } from '@angular/core';
 import { ActivatedRoute } from '@angular/router';
 import { VmService } from '../../state/vms/vms.service';
 import { ThemeService } from '../../services/theme/theme.service';
@@ -15,9 +15,9 @@ import { PageNotFoundComponent } from '../page-not-found/page-not-found.componen
   imports: [PageNotFoundComponent],
 })
 export class ConsoleComponent implements OnInit {
-  loading = true;
-  notFound = false;
-  name = '';
+  loading = signal(true);
+  notFound = signal(false);
+  name = signal('');
 
   constructor(
     private vmService: VmService,
@@ -27,22 +27,22 @@ export class ConsoleComponent implements OnInit {
 
   ngOnInit() {
     const viewId = this.route.snapshot.params['viewId'];
-    this.name = this.route.snapshot.params['name'];
+    this.name.set(this.route.snapshot.params['name']);
 
-    this.vmService.GetViewVmsByName(viewId, this.name).subscribe(
+    this.vmService.GetViewVmsByName(viewId, this.name()).subscribe(
       (vms) => {
         const vm = vms != null ? vms[0] : null;
 
         if (vm) {
           window.location.href = this.themeService.addThemeQueryParam(vm.url);
         } else {
-          this.loading = false;
-          this.notFound = true;
+          this.loading.set(false);
+          this.notFound.set(true);
         }
       },
       (err) => {
-        this.loading = false;
-        this.notFound = true;
+        this.loading.set(false);
+        this.notFound.set(true);
       },
     );
   }

--- a/src/app/components/map/map-main/map-main.component.html
+++ b/src/app/components/map/map-main/map-main.component.html
@@ -7,7 +7,9 @@ Released under a MIT (SEI)-style license. See LICENSE.md in the project root for
 <app-topbar></app-topbar>
 }
 
-@if (!(viewExists$ | async)) {
+@if (loading) {
+  Loading...
+} @else if (!viewExists) {
   <app-page-not-found></app-page-not-found>
 } @else {
 <div class="pt-1 d-flex align-items-center justify-content-center gap-2">

--- a/src/app/components/map/map-main/map-main.component.html
+++ b/src/app/components/map/map-main/map-main.component.html
@@ -7,9 +7,9 @@ Released under a MIT (SEI)-style license. See LICENSE.md in the project root for
 <app-topbar></app-topbar>
 }
 
-@if (loading) {
+@if (loading()) {
   Loading...
-} @else if (!viewExists) {
+} @else if (!viewExists()) {
   <app-page-not-found></app-page-not-found>
 } @else {
 <div class="pt-1 d-flex align-items-center justify-content-center gap-2">

--- a/src/app/components/map/map-main/map-main.component.ts
+++ b/src/app/components/map/map-main/map-main.component.ts
@@ -7,6 +7,7 @@ import {
   Component,
   OnDestroy,
   OnInit,
+  signal,
   TemplateRef,
   ViewChild,
 } from '@angular/core';
@@ -77,8 +78,8 @@ export class MapMainComponent implements OnDestroy, OnInit, AfterViewChecked {
   private unsubscribe$ = new Subject();
   maps: VmMap[] = [];
   canEdit$: Observable<boolean>;
-  viewExists = false;
-  loading = true;
+  viewExists = signal(false);
+  loading = signal(true);
 
   constructor(
     private permissionsService: UserPermissionsService,
@@ -94,7 +95,7 @@ export class MapMainComponent implements OnDestroy, OnInit, AfterViewChecked {
     this.route.params
       .pipe(
         tap((params) => {
-          this.loading = true;
+          this.loading.set(true);
           this.vmMapsService.unload();
           this.viewId = params['viewId'];
         }),
@@ -119,7 +120,7 @@ export class MapMainComponent implements OnDestroy, OnInit, AfterViewChecked {
         // the template: a view with no maps still has a team, and this avoids
         // the initial null emission that briefly flashed "View Not Found".
         switchMap(() => this.permissionsService.getPrimaryTeamId(this.viewId!)),
-        tap((teamId) => (this.viewExists = !!teamId)),
+        tap((teamId) => this.viewExists.set(!!teamId)),
         switchMap(() => this.getFilteredMaps(this.viewId!)),
         tap((filteredMaps) => {
           this.maps = filteredMaps;
@@ -130,12 +131,12 @@ export class MapMainComponent implements OnDestroy, OnInit, AfterViewChecked {
             this.selected = filteredMaps[0];
             this.goToMap();
           }
-          this.loading = false;
+          this.loading.set(false);
         }),
         takeUntil(this.unsubscribe$),
       )
       .subscribe({
-        error: () => (this.loading = false),
+        error: () => this.loading.set(false),
       });
   }
 

--- a/src/app/components/map/map-main/map-main.component.ts
+++ b/src/app/components/map/map-main/map-main.component.ts
@@ -141,7 +141,12 @@ export class MapMainComponent implements OnDestroy, OnInit, AfterViewChecked {
   }
 
   private getFilteredMaps(viewId: string): Observable<VmMap[]> {
-    return this.vmMapQuery.selectAll().pipe(
+    // Wait until the maps request settles before reading the store; otherwise
+    // the empty (just-unloaded) store state emits first and briefly flashes
+    // "No Map is assigned to this Team" before the maps arrive.
+    return this.vmMapQuery.selectLoading().pipe(
+      filter((isLoading) => !isLoading),
+      switchMap(() => this.vmMapQuery.selectAll()),
       switchMap((maps) =>
         this.permissionsService.getPrimaryTeamId(viewId).pipe(
           switchMap((primaryTeamId) => {

--- a/src/app/components/map/map-main/map-main.component.ts
+++ b/src/app/components/map/map-main/map-main.component.ts
@@ -77,7 +77,8 @@ export class MapMainComponent implements OnDestroy, OnInit, AfterViewChecked {
   private unsubscribe$ = new Subject();
   maps: VmMap[] = [];
   canEdit$: Observable<boolean>;
-  viewExists$: Observable<boolean>;
+  viewExists = false;
+  loading = true;
 
   constructor(
     private permissionsService: UserPermissionsService,
@@ -93,6 +94,7 @@ export class MapMainComponent implements OnDestroy, OnInit, AfterViewChecked {
     this.route.params
       .pipe(
         tap((params) => {
+          this.loading = true;
           this.vmMapsService.unload();
           this.viewId = params['viewId'];
         }),
@@ -106,12 +108,6 @@ export class MapMainComponent implements OnDestroy, OnInit, AfterViewChecked {
             AppTeamPermission.ManageTeam,
             AppViewPermission.ManageView,
           );
-          // Assign here, not in the maps pipeline below: a view with no maps
-          // never emits there, leaving viewExists$ undefined and falsely
-          // showing "View Not Found". View existence depends only on the team.
-          this.viewExists$ = this.permissionsService
-            .getPrimaryTeamId(this.viewId!)
-            .pipe(map((teamId) => !!teamId));
         }),
         switchMap(() =>
           forkJoin([
@@ -119,6 +115,11 @@ export class MapMainComponent implements OnDestroy, OnInit, AfterViewChecked {
             this.permissionsService.loadTeamPermissions(this.viewId!),
           ]),
         ),
+        // Resolve view existence from the team here, not as an async pipe in
+        // the template: a view with no maps still has a team, and this avoids
+        // the initial null emission that briefly flashed "View Not Found".
+        switchMap(() => this.permissionsService.getPrimaryTeamId(this.viewId!)),
+        tap((teamId) => (this.viewExists = !!teamId)),
         switchMap(() => this.getFilteredMaps(this.viewId!)),
         tap((filteredMaps) => {
           this.maps = filteredMaps;
@@ -129,10 +130,13 @@ export class MapMainComponent implements OnDestroy, OnInit, AfterViewChecked {
             this.selected = filteredMaps[0];
             this.goToMap();
           }
+          this.loading = false;
         }),
         takeUntil(this.unsubscribe$),
       )
-      .subscribe();
+      .subscribe({
+        error: () => (this.loading = false),
+      });
   }
 
   private getFilteredMaps(viewId: string): Observable<VmMap[]> {

--- a/src/app/components/page-not-found/page-not-found.component.html
+++ b/src/app/components/page-not-found/page-not-found.component.html
@@ -4,6 +4,6 @@ Released under a MIT (SEI)-style license. See LICENSE.md in the project root for
 -->
 
 <div class="d-flex flex-column align-items-center justify-content-center" style="height: 100%; padding: 2rem;">
-  <h2>View Not Found</h2>
-  <p>The view you are trying to access no longer exists or you do not have permission to access it.</p>
+  <h2>{{ heading }}</h2>
+  <p>{{ message }}</p>
 </div>

--- a/src/app/components/page-not-found/page-not-found.component.ts
+++ b/src/app/components/page-not-found/page-not-found.component.ts
@@ -1,7 +1,7 @@
 // Copyright 2021 Carnegie Mellon University. All Rights Reserved.
 // Released under a MIT (SEI)-style license. See LICENSE.md in the project root for license information.
 
-import { Component } from '@angular/core';
+import { Component, Input } from '@angular/core';
 
 @Component({
   selector: 'app-page-not-found',
@@ -9,4 +9,8 @@ import { Component } from '@angular/core';
   styleUrls: ['./page-not-found.component.scss'],
   standalone: true,
 })
-export class PageNotFoundComponent {}
+export class PageNotFoundComponent {
+  @Input() heading = 'View Not Found';
+  @Input() message =
+    'The view you are trying to access no longer exists or you do not have permission to access it.';
+}


### PR DESCRIPTION
## Overview

Fixes several related "silent hang / flash before load" issues in the VM UI caused by not-found and empty states rendering before async data has resolved.

## 1. Console-by-name lookup hung on empty results

Clicking a map clickpoint for a VM routes to `views/:viewId/vms/:name/console`, where `ConsoleComponent` looks the VM up by name (filtered by the user's permissions) and redirects to its console URL.

If the lookup returned **no results** — the VM name doesn't exist, or the user lacks permission to see it — the old code silently did nothing (`if (vms != null)` passes for `[]`, so `vms[0]` is `undefined` and the redirect was skipped), leaving the page hung on the static text `Loading...`.

- `ConsoleComponent` now tracks `loading` / `notFound` state and redirects only when an accessible VM is found; otherwise (empty result **or** request error) it shows a not-found message.
- Reused `PageNotFoundComponent` for the message so it matches the existing "View Not Found" page styling. That component gained optional `heading` / `message` `@Input`s whose defaults equal the original hardcoded text, so the wildcard route and existing `vm-main` / `map-main` usages render unchanged.

## 2. Map page flashed "View Not Found" / "No Map is assigned" before load

`MapMainComponent` briefly showed "View Not Found" and/or "No Map is assigned to this Team" before the real map rendered, because both conditions evaluated true before async data arrived (no loading guard). Added a `loading` guard and resolved view existence to a plain value within the params pipeline (instead of an uninitialized async-pipe observable), so the template shows `Loading...` until data is ready. Genuine no-map / nonexistent-view states still surface after loading.

## 3. Intermittent "No Map is assigned" flash on reload (race condition)

Even with the guard, "No Map is assigned" still flashed intermittently on reload. `getFilteredMaps()` subscribed to the live Akita store immediately, so when the just-unloaded (empty) store emitted before the `getViewMaps` HTTP response arrived, the empty state rendered first. Gated `getFilteredMaps()` on the store's `selectLoading()` flag so it waits for the maps request to settle before reading state. A view genuinely with no maps still resolves to an empty list after loading, preserving its steady message.

## Notes

- New component state (`loading` / `notFound` / `name` / `viewExists`) uses signals, per Angular's current best-practice guidance.