### PR TITLE
Bump crucible-common to 0.7.3

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -19,7 +19,7 @@
         "@angular/platform-browser": "^21.2.1",
         "@angular/platform-browser-dynamic": "^21.2.1",
         "@angular/router": "^21.2.1",
-        "@cmusei/crucible-common": "0.7.2",
+        "@cmusei/crucible-common": "0.7.3",
         "@datorama/akita": "^8.0.1",
         "@datorama/akita-ng-router-store": "^8.0.0",
         "@material/material-color-utilities": "^0.4.0",
@@ -2514,9 +2514,9 @@
       }
     },
     "node_modules/@cmusei/crucible-common": {
-      "version": "0.7.2",
-      "resolved": "https://registry.npmjs.org/@cmusei/crucible-common/-/crucible-common-0.7.2.tgz",
-      "integrity": "sha512-wIxhKoylCBOmh/92TrZWoZkIZyDoqATHQKXLvOafKWoyBbB4D6oM78BoFdqu5mzDnOi5qQe2R2Dt1/dDptEwvg==",
+      "version": "0.7.3",
+      "resolved": "https://registry.npmjs.org/@cmusei/crucible-common/-/crucible-common-0.7.3.tgz",
+      "integrity": "sha512-Cr5ZVc/eWouo2+Xty7KTEy59zgSFKzTDESwxBnQz0opuFyVx8x2w3MAU1A0/OIR52iUbiQ13IsMnhDHNdhWwEw==",
       "license": "MIT",
       "dependencies": {
         "tslib": "^2.4.1"

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "@angular/platform-browser": "^21.2.1",
     "@angular/platform-browser-dynamic": "^21.2.1",
     "@angular/router": "^21.2.1",
-    "@cmusei/crucible-common": "0.7.2",
+    "@cmusei/crucible-common": "0.7.3",
     "@datorama/akita": "^8.0.1",
     "@datorama/akita-ng-router-store": "^8.0.0",
     "@material/material-color-utilities": "^0.4.0",


### PR DESCRIPTION
## Summary

Bumps `@cmusei/crucible-common` from `0.7.2` to `0.7.3`.

**What 0.7.3 provides:**
- **Cancel now closes `crucible-dialog` via the injected `MatDialogRef` instead of a bare `mat-dialog-close` attribute.** Previously the bare attribute made Angular close with `''` (empty string) rather than `undefined`, which slipped past `result ?? {...}` and `!result.wasCancelled` guards — a cancelled dialog could be treated as a real result.
- **Loading-state layout fix**: the primary button's label and `<mat-progress-spinner>` are now wrapped and laid out as one centered inline-flex row, fixing the spinner dropping to its own line beneath the label text while `loading` is set.

**Impact on vm.ui:**
- No code changes were required — this app's `crucible-dialog` consumers don't rely on the affected `wasCancelled`/empty-string cancel result, so the fix is a drop-in dependency bump.
