### PR TITLE
Add Proxmox network permissions support

### DIFF
--- a/src/app/components/network-permissions/network-permissions.component.html
+++ b/src/app/components/network-permissions/network-permissions.component.html
@@ -23,7 +23,7 @@ Released under a MIT (SEI)-style license. See LICENSE.md in the project root for
         <input
           matInput
           [formControl]="providerInstanceIdControl"
-          matTooltip="The address of the vSphere server (e.g. vcenter.example.com)"
+          [matTooltip]="getProviderInstanceTooltip(providerTypeControl.value)"
         />
       </mat-form-field>
 
@@ -32,7 +32,7 @@ Released under a MIT (SEI)-style license. See LICENSE.md in the project root for
         <input
           matInput
           [formControl]="networkIdControl"
-          matTooltip="The Managed Object ID (MOID) of the network"
+          [matTooltip]="getNetworkIdTooltip(providerTypeControl.value)"
         />
       </mat-form-field>
 

--- a/src/app/components/network-permissions/network-permissions.component.html
+++ b/src/app/components/network-permissions/network-permissions.component.html
@@ -8,7 +8,7 @@ Released under a MIT (SEI)-style license. See LICENSE.md in the project root for
   <p>Configure access to existing Networks for Teams in this View.</p>
 
   @if (canManage) {
-    <div class="create-form">
+    <form class="create-form" (ngSubmit)="createNetwork()">
       <mat-form-field>
         <mat-label>Provider Type</mat-label>
         <mat-select [formControl]="providerTypeControl">
@@ -18,21 +18,21 @@ Released under a MIT (SEI)-style license. See LICENSE.md in the project root for
         </mat-select>
       </mat-form-field>
 
-      <mat-form-field>
+      <mat-form-field
+        [matTooltip]="providerInstanceTooltip()"
+      >
         <mat-label>Provider Instance ID</mat-label>
         <input
           matInput
           [formControl]="providerInstanceIdControl"
-          [matTooltip]="getProviderInstanceTooltip(providerTypeControl.value)"
         />
       </mat-form-field>
 
-      <mat-form-field>
+      <mat-form-field [matTooltip]="networkIdTooltip()">
         <mat-label>Network ID</mat-label>
         <input
           matInput
           [formControl]="networkIdControl"
-          [matTooltip]="getNetworkIdTooltip(providerTypeControl.value)"
         />
       </mat-form-field>
 
@@ -58,24 +58,40 @@ Released under a MIT (SEI)-style license. See LICENSE.md in the project root for
         mat-raised-button
         color="primary"
         class="button-cmd"
-        (click)="createNetwork()"
+        type="submit"
       >
         Add
       </button>
-    </div>
+    </form>
   }
 
   <mat-toolbar class="toolbar">
     <mat-form-field class="search-field" subscriptSizing="dynamic">
       <mat-label>Search</mat-label>
-      <input matInput [(ngModel)]="filterString" (ngModelChange)="applyFilter($event)" placeholder="Filter networks..." />
+      <input
+        matInput
+        [(ngModel)]="filterString"
+        (ngModelChange)="applyFilter($event)"
+        placeholder="Filter networks..."
+      />
       @if (filterString) {
-        <button matSuffix mat-icon-button color="primary" (click)="filterString = ''; applyFilter('')" title="Clear Search">
+        <button
+          matSuffix
+          mat-icon-button
+          color="primary"
+          (click)="filterString = ''; applyFilter('')"
+          title="Clear Search"
+        >
           <mat-icon class="mdi-24px" fontIcon="mdi-close-circle"></mat-icon>
         </button>
       }
     </mat-form-field>
-    <button mat-raised-button color="primary" class="button-cmd" (click)="refresh()">
+    <button
+      mat-raised-button
+      color="primary"
+      class="button-cmd"
+      (click)="refresh()"
+    >
       Refresh
     </button>
   </mat-toolbar>
@@ -83,13 +99,19 @@ Released under a MIT (SEI)-style license. See LICENSE.md in the project root for
   <div class="mat-elevation-z8 table-container">
     <mat-table [dataSource]="dataSource" matSort>
       <ng-container matColumnDef="providerType">
-        <mat-header-cell *matHeaderCellDef mat-sort-header>Provider Type</mat-header-cell>
+        <mat-header-cell *matHeaderCellDef mat-sort-header
+          >Provider Type</mat-header-cell
+        >
         <mat-cell *matCellDef="let row">
           @if (canManage) {
             <mat-form-field>
-              <mat-select [formControl]="getRowForm(row).controls['providerType']">
+              <mat-select
+                [formControl]="getRowForm(row).controls['providerType']"
+              >
                 @for (pt of providerTypes; track pt) {
-                  <mat-option [value]="pt">{{ getProviderTypeLabel(pt) }}</mat-option>
+                  <mat-option [value]="pt">{{
+                    getProviderTypeLabel(pt)
+                  }}</mat-option>
                 }
               </mat-select>
             </mat-form-field>
@@ -100,11 +122,16 @@ Released under a MIT (SEI)-style license. See LICENSE.md in the project root for
       </ng-container>
 
       <ng-container matColumnDef="providerInstanceId">
-        <mat-header-cell *matHeaderCellDef mat-sort-header>Provider Instance</mat-header-cell>
+        <mat-header-cell *matHeaderCellDef mat-sort-header
+          >Provider Instance</mat-header-cell
+        >
         <mat-cell *matCellDef="let row">
           @if (canManage) {
             <mat-form-field>
-              <input matInput [formControl]="getRowForm(row).controls['providerInstanceId']" />
+              <input
+                matInput
+                [formControl]="getRowForm(row).controls['providerInstanceId']"
+              />
             </mat-form-field>
           } @else {
             {{ row.providerInstanceId }}
@@ -113,11 +140,16 @@ Released under a MIT (SEI)-style license. See LICENSE.md in the project root for
       </ng-container>
 
       <ng-container matColumnDef="networkId">
-        <mat-header-cell *matHeaderCellDef mat-sort-header>Network ID</mat-header-cell>
+        <mat-header-cell *matHeaderCellDef mat-sort-header
+          >Network ID</mat-header-cell
+        >
         <mat-cell *matCellDef="let row">
           @if (canManage) {
             <mat-form-field>
-              <input matInput [formControl]="getRowForm(row).controls['networkId']" />
+              <input
+                matInput
+                [formControl]="getRowForm(row).controls['networkId']"
+              />
             </mat-form-field>
           } @else {
             {{ row.networkId }}
@@ -126,11 +158,16 @@ Released under a MIT (SEI)-style license. See LICENSE.md in the project root for
       </ng-container>
 
       <ng-container matColumnDef="name">
-        <mat-header-cell *matHeaderCellDef mat-sort-header>Name</mat-header-cell>
+        <mat-header-cell *matHeaderCellDef mat-sort-header
+          >Name</mat-header-cell
+        >
         <mat-cell *matCellDef="let row">
           @if (canManage) {
             <mat-form-field>
-              <input matInput [formControl]="getRowForm(row).controls['name']" />
+              <input
+                matInput
+                [formControl]="getRowForm(row).controls['name']"
+              />
             </mat-form-field>
           } @else {
             {{ row.name }}
@@ -139,11 +176,16 @@ Released under a MIT (SEI)-style license. See LICENSE.md in the project root for
       </ng-container>
 
       <ng-container matColumnDef="teamIds">
-        <mat-header-cell *matHeaderCellDef mat-sort-header>Assigned Teams</mat-header-cell>
+        <mat-header-cell *matHeaderCellDef mat-sort-header
+          >Assigned Teams</mat-header-cell
+        >
         <mat-cell *matCellDef="let row">
           @if (canManage) {
             <mat-form-field>
-              <mat-select [formControl]="getRowForm(row).controls['teamIds']" multiple>
+              <mat-select
+                [formControl]="getRowForm(row).controls['teamIds']"
+                multiple
+              >
                 @for (team of teams; track team.id) {
                   <mat-option [value]="team.id">{{ team.name }}</mat-option>
                 }
@@ -164,11 +206,23 @@ Released under a MIT (SEI)-style license. See LICENSE.md in the project root for
         <mat-header-cell *matHeaderCellDef>Actions</mat-header-cell>
         <mat-cell *matCellDef="let row">
           @if (canManage) {
-            <button mat-icon-button (click)="saveRow(row)" matTooltip="Save" [disabled]="!isRowDirty(row)">
+            <button
+              mat-icon-button
+              (click)="saveRow(row)"
+              matTooltip="Save"
+              [disabled]="!isRowDirty(row)"
+            >
               <mat-icon class="mdi-24px" fontIcon="mdi-content-save"></mat-icon>
             </button>
-            <button mat-icon-button (click)="deleteNetwork(row)" matTooltip="Delete">
-              <mat-icon class="mdi-24px" fontIcon="mdi-trash-can-outline"></mat-icon>
+            <button
+              mat-icon-button
+              (click)="deleteNetwork(row)"
+              matTooltip="Delete"
+            >
+              <mat-icon
+                class="mdi-24px"
+                fontIcon="mdi-trash-can-outline"
+              ></mat-icon>
             </button>
           }
         </mat-cell>
@@ -177,6 +231,9 @@ Released under a MIT (SEI)-style license. See LICENSE.md in the project root for
       <mat-header-row *matHeaderRowDef="displayedColumns"></mat-header-row>
       <mat-row *matRowDef="let row; columns: displayedColumns"></mat-row>
     </mat-table>
-    <mat-paginator [pageSizeOptions]="[5, 10, 20]" showFirstLastButtons></mat-paginator>
+    <mat-paginator
+      [pageSizeOptions]="[5, 10, 20]"
+      showFirstLastButtons
+    ></mat-paginator>
   </div>
 </div>

--- a/src/app/components/network-permissions/network-permissions.component.ts
+++ b/src/app/components/network-permissions/network-permissions.component.ts
@@ -7,9 +7,11 @@ import {
   Input,
   OnDestroy,
   ViewChild,
+  computed,
 } from '@angular/core';
+import { toSignal } from '@angular/core/rxjs-interop';
 import { BehaviorSubject, Subject } from 'rxjs';
-import { switchMap, take, takeUntil } from 'rxjs/operators';
+import { startWith, switchMap, take, takeUntil } from 'rxjs/operators';
 import {
   NetworksService,
   ViewNetwork,
@@ -108,6 +110,22 @@ export class NetworkPermissionsComponent implements AfterViewInit, OnDestroy {
   networkIdControl = new UntypedFormControl('', [Validators.required]);
   nameControl = new UntypedFormControl('', [Validators.required]);
   teamIdsControl = new UntypedFormControl([]);
+  private readonly providerType = toSignal(
+    this.providerTypeControl.valueChanges.pipe(
+      startWith(this.providerTypeControl.value),
+    ),
+    { initialValue: this.providerTypeControl.value },
+  );
+  readonly providerInstanceTooltip = computed(() =>
+    this.providerType() === VmType.Proxmox
+      ? 'The address of the Proxmox server (e.g. proxmox.example.com)'
+      : 'The address of the vSphere server (e.g. vcenter.example.com)',
+  );
+  readonly networkIdTooltip = computed(() =>
+    this.providerType() === VmType.Proxmox
+      ? 'The Proxmox bridge name (e.g. vmbr100)'
+      : 'The Managed Object ID (MOID) of the network',
+  );
 
   providerTypes = [VmType.Vsphere, VmType.Proxmox];
   providerTypeLabels: Record<string, string> = {
@@ -289,18 +307,6 @@ export class NetworkPermissionsComponent implements AfterViewInit, OnDestroy {
 
   getProviderTypeLabel(value: string): string {
     return this.providerTypeLabels[value] || value;
-  }
-
-  getProviderInstanceTooltip(providerType: string): string {
-    return providerType === VmType.Proxmox
-      ? 'The Proxmox host configured for Player VM (e.g. proxmox.example.com)'
-      : 'The address of the vSphere server (e.g. vcenter.example.com)';
-  }
-
-  getNetworkIdTooltip(providerType: string): string {
-    return providerType === VmType.Proxmox
-      ? 'The Proxmox bridge name (e.g. vmbr100)'
-      : 'The Managed Object ID (MOID) of the network';
   }
 
   getTeamName(teamId: string): string {

--- a/src/app/components/network-permissions/network-permissions.component.ts
+++ b/src/app/components/network-permissions/network-permissions.component.ts
@@ -109,8 +109,11 @@ export class NetworkPermissionsComponent implements AfterViewInit, OnDestroy {
   nameControl = new UntypedFormControl('', [Validators.required]);
   teamIdsControl = new UntypedFormControl([]);
 
-  providerTypes = [VmType.Vsphere];
-  providerTypeLabels: Record<string, string> = { Vsphere: 'vSphere' };
+  providerTypes = [VmType.Vsphere, VmType.Proxmox];
+  providerTypeLabels: Record<string, string> = {
+    Vsphere: 'vSphere',
+    Proxmox: 'Proxmox',
+  };
 
   displayedColumns: string[] = [
     'providerType',
@@ -286,6 +289,18 @@ export class NetworkPermissionsComponent implements AfterViewInit, OnDestroy {
 
   getProviderTypeLabel(value: string): string {
     return this.providerTypeLabels[value] || value;
+  }
+
+  getProviderInstanceTooltip(providerType: string): string {
+    return providerType === VmType.Proxmox
+      ? 'The Proxmox host configured for Player VM (e.g. proxmox.example.com)'
+      : 'The address of the vSphere server (e.g. vcenter.example.com)';
+  }
+
+  getNetworkIdTooltip(providerType: string): string {
+    return providerType === VmType.Proxmox
+      ? 'The Proxmox bridge name (e.g. vmbr100)'
+      : 'The Managed Object ID (MOID) of the network';
   }
 
   getTeamName(teamId: string): string {


### PR DESCRIPTION
## Summary

Adds Proxmox as a supported provider when configuring view network permissions.

## User-facing changes

- Adds Proxmox to the provider type selector.
- Shows Proxmox-specific guidance for the provider instance address and bridge network ID.
- Preserves the existing vSphere guidance when vSphere is selected.
- Makes the Add network form submit through the form submit event.

## Technical details

- Uses the selected provider type to compute context-sensitive tooltips.
- Keeps the existing network table editing, filtering, and refresh behavior unchanged.